### PR TITLE
Parse fraction characters

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: ruby
+sudo: false
 
 rvm:
   - 1.9.3

--- a/lib/ruby-measurement/core_ext/string.rb
+++ b/lib/ruby-measurement/core_ext/string.rb
@@ -4,7 +4,7 @@ class String
   def to_measurement
     Measurement.parse(self)
   end
-  
+
   def to_unit
     Measurement::Unit[self] or raise ArgumentError, "Invalid unit: #{self}"
   end

--- a/lib/ruby-measurement/measurement.rb
+++ b/lib/ruby-measurement/measurement.rb
@@ -1,3 +1,5 @@
+# encoding: UTF-8
+
 require 'ruby-measurement/unit'
 require 'ruby-measurement/version'
 
@@ -7,28 +9,46 @@ class Measurement
   SCIENTIFIC_REGEX  = /\A#{SCIENTIFIC_NUMBER}\s*#{UNIT_REGEX}?\z/.freeze
   RATIONAL_REGEX    = /\A([+-]?\d+\s+)?((\d+)\/(\d+))?\s*#{UNIT_REGEX}?\z/.freeze
   COMPLEX_REGEX     = /\A#{SCIENTIFIC_NUMBER}?#{SCIENTIFIC_NUMBER}i\s*#{UNIT_REGEX}?\z/.freeze
-  
+
+  RATIOS = {
+    '¼' => '1/4',
+    '½' => '1/2',
+    '¾' => '3/4',
+    '⅓' => '1/3',
+    '⅔' => '2/3',
+    '⅕' => '1/5',
+    '⅖' => '2/5',
+    '⅗' => '3/5',
+    '⅘' => '4/5',
+    '⅙' => '1/6',
+    '⅚' => '5/6',
+    '⅛' => '1/8',
+    '⅜' => '3/8',
+    '⅝' => '5/8',
+    '⅞' => '7/8',
+  }.freeze
+
   attr_reader :quantity, :unit
-  
+
   def initialize(quantity, unit_name = :count)
     unit = unit_name
     unit = Unit[unit_name.to_s] if unit_name.kind_of?(Symbol) || unit_name.kind_of?(String)
-    
+
     raise ArgumentError, "Invalid quantity: #{quantity}" unless quantity.kind_of?(Numeric)
     raise ArgumentError, "Invalid unit: #{unit_name}" unless unit.kind_of?(Unit)
-    
+
     @quantity = quantity
     @unit = unit
   end
-  
+
   def inspect
     to_s
   end
-  
+
   def to_s
     "#{quantity} #{unit}"
   end
-  
+
   %w(+ - * /).each do |operator|
     class_eval <<-END, __FILE__, __LINE__ + 1
       def #{operator}(obj)
@@ -47,7 +67,7 @@ class Measurement
       end
     END
   end
-  
+
   def **(obj)
     case obj
     when Numeric
@@ -56,82 +76,96 @@ class Measurement
       raise ArgumentError, "Invalid arithmetic: #{self} ** #{obj}"
     end
   end
-  
+
   def ==(obj)
     obj.kind_of?(self.class) && quantity == obj.quantity && unit == obj.unit
   end
-  
+
   def convert_to(unit_name)
     unit = Unit[unit_name]
     raise ArgumentError, "Invalid unit: '#{unit_name}'" unless unit
-    
+
     return dup if unit == @unit
-    
+
     conversion = @unit.conversion(unit.name)
     raise ArgumentError, "Invalid conversion: '#@unit' to '#{unit.name}'" unless conversion
-    
+
     self.class.new(conversion.call(@quantity), unit.name)
   end
-  
+
   def convert_to!(unit_name)
     measurement = convert_to(unit_name)
     @unit, @quantity = measurement.unit, measurement.quantity
     self
   end
-  
-  def self.parse(str = '0')
-    str = str.strip
-    
-    case str
-      when COMPLEX_REGEX then unit_name, quantity = parse_complex(str)
-      when SCIENTIFIC_REGEX then unit_name, quantity = parse_scientific(str)
-      when RATIONAL_REGEX then unit_name, quantity = parse_rational(str)
-      else raise ArgumentError, "Unable to parse: '#{str}'"
+
+  class << self
+    def parse(str = '0')
+      str = normalize(str)
+
+      case str
+        when COMPLEX_REGEX then unit_name, quantity = parse_complex(str)
+        when SCIENTIFIC_REGEX then unit_name, quantity = parse_scientific(str)
+        when RATIONAL_REGEX then unit_name, quantity = parse_rational(str)
+        else raise ArgumentError, "Unable to parse: '#{str}'"
+      end
+
+      unit_name ||= 'count'
+      unit = Unit[unit_name.strip.downcase]
+      raise ArgumentError, "Invalid unit: '#{unit_name}'" unless unit
+
+      new(quantity, unit)
     end
-    
-    unit_name ||= 'count'
-    unit = Unit[unit_name.strip.downcase]
-    raise ArgumentError, "Invalid unit: '#{unit_name}'" unless unit
-    
-    new(quantity, unit)
-  end
-  
-  def self.define(unit_name, &block)
-    Unit.define(unit_name, &block)
-  end
-  
-  private
-  
-  def self.parse_complex(str)
-    real, imaginary, unit_name = str.scan(COMPLEX_REGEX).first
-    quantity = Complex(real.to_f, imaginary.to_f).to_f
-    return unit_name, quantity
-  end
-  
-  def self.parse_scientific(str)
-    whole, unit_name = str.scan(SCIENTIFIC_REGEX).first
-    quantity = whole.to_f
-    return unit_name, quantity
-  end
-  
-  def self.parse_rational(str)
-    whole, _, numerator, denominator, unit_name = str.scan(RATIONAL_REGEX).first
-    
-    if numerator && denominator
-      numerator = numerator.to_f + (denominator.to_f * whole.to_f)
-      denominator = denominator.to_f
-      quantity = Rational(numerator, denominator).to_f
-    else
+
+    def define(unit_name, &block)
+      Unit.define(unit_name, &block)
+    end
+
+    private
+
+    def normalize(str)
+      str.dup.tap do |str|
+        if str =~ Regexp.new(/(#{RATIOS.keys.join('|')})/)
+          RATIOS.each do |search, replace|
+            str.gsub!(search) { " #{replace}" }
+          end
+        end
+
+        str.strip!
+      end
+    end
+
+    def parse_complex(str)
+      real, imaginary, unit_name = str.scan(COMPLEX_REGEX).first
+      quantity = Complex(real.to_f, imaginary.to_f).to_f
+      return unit_name, quantity
+    end
+
+    def parse_scientific(str)
+      whole, unit_name = str.scan(SCIENTIFIC_REGEX).first
       quantity = whole.to_f
+      return unit_name, quantity
     end
-    
-    return unit_name, quantity
+
+    def parse_rational(str)
+      whole, _, numerator, denominator, unit_name = str.scan(RATIONAL_REGEX).first
+
+      if numerator && denominator
+        numerator = numerator.to_f + (denominator.to_f * whole.to_f)
+        denominator = denominator.to_f
+        quantity = Rational(numerator, denominator).to_f
+      else
+        quantity = whole.to_f
+      end
+
+      return unit_name, quantity
+    end
   end
-  
+
   define(:count) do |unit|
     unit.convert_to(:dozen) { |value| value / 12.0 }
   end
-  
+
   define(:doz) do |unit|
     unit.alias :dozen
     unit.convert_to(:count) { |value| value * 12.0 }

--- a/lib/ruby-measurement/unit.rb
+++ b/lib/ruby-measurement/unit.rb
@@ -3,85 +3,85 @@ require 'set'
 class Measurement
   class Unit
     attr_reader :name, :aliases, :conversions
-    
+
     @definitions = {}
-    
+
     def initialize(name)
       @name = name.to_s
       @aliases = Set.new
       @conversions = {}
       add_alias(name)
     end
-    
+
     def add_alias(*args)
       args.each do |unit_alias|
         @aliases << unit_alias.to_s
         self.class[unit_alias] = self
       end
     end
-    
+
     def add_conversion(unit_name, &block)
       @conversions[unit_name.to_s] = block
     end
-    
+
     def conversion(unit_name)
       unit = self.class[unit_name]
       return nil unless unit
-      
+
       unit.aliases.each do |unit_alias|
         conversion = @conversions[unit_alias.to_s]
         return conversion if conversion
       end
-      
+
       nil
     end
-    
+
     def inspect
       to_s
     end
-    
+
     def to_s
       name
     end
-    
+
     def ==(obj)
       obj.kind_of?(self.class) && name == obj.name && aliases == obj.aliases && conversions.all? do |key, proc|
         [-2.5, -1, 0, 1, 2.5].all? { |n| proc.call(n) == obj.conversions[key].call(n) }
       end
     end
-    
-    def self.define(unit_name, &block)
-      Builder.new(unit_name, &block)
+
+    class << self
+      def define(unit_name, &block)
+        Builder.new(unit_name, &block)
+      end
+
+      def [](unit_name)
+        @definitions[unit_name.to_s.downcase]
+      end
+
+      def []=(unit_name, unit)
+        @definitions[unit_name.to_s.downcase] = unit
+      end
+
+      def names
+        @definitions.keys
+      end
     end
-    
-    def self.[](unit_name)
-      @definitions[unit_name.to_s.downcase]
-    end
-    
-    def self.names
-      @definitions.keys
-    end
-    
-    private
-    
-    def self.[]=(unit_name, unit)
-      @definitions[unit_name.to_s.downcase] = unit
-    end
-    
+
     class Builder
       def initialize(unit_name, &block)
         @unit = Unit.new(unit_name)
         block.call(self) if block_given?
       end
-      
+
       def alias(*args)
         @unit.add_alias(*args)
       end
-      
+
       def convert_to(unit_name, &block)
         @unit.add_conversion(unit_name, &block)
       end
-      
+
       def to_unit
         @unit
       end

--- a/spec/ruby-measurement/core_ext/string_spec.rb
+++ b/spec/ruby-measurement/core_ext/string_spec.rb
@@ -6,29 +6,29 @@ RSpec.describe String do
       subject { '3' }
       specify { expect(subject.to_measurement).to eq Measurement.new(3) }
     end
-    
+
     describe 'with valid quantity and unit' do
       subject { '3 dozen' }
       specify { expect(subject.to_measurement).to eq Measurement.new(3, :dozen) }
     end
-    
+
     describe 'with valid quantity and invalid unit' do
       subject { '3 people' }
       specify { expect { subject.to_measurement }.to raise_error }
     end
-    
+
     describe 'with invalid input' do
       subject { 'foobar' }
       specify { expect { subject.to_measurement }.to raise_error }
     end
   end
-  
+
   describe '#to_unit' do
     describe 'with valid unit' do
       subject { 'dozen' }
       specify { expect(subject.to_unit).to eq Measurement::Unit[:dozen] }
     end
-    
+
     describe 'with invalid unit' do
       subject { 'person' }
       specify { expect { subject.to_unit }.to raise_error }

--- a/spec/ruby-measurement/definitions/metric/area_spec.rb
+++ b/spec/ruby-measurement/definitions/metric/area_spec.rb
@@ -5,63 +5,63 @@ require 'spec_helper'
 RSpec.describe Measurement do
   describe 'square kilometers' do
     subject { described_class.parse('10 km²') }
-    
+
     it 'converts to hectares' do
       expect(subject.convert_to(:ha).quantity).to eq 1_000
     end
-    
+
     it 'converts to ares' do
       expect(subject.convert_to(:a).quantity).to eq 100_000
     end
-    
+
     it 'converts to square centimeters' do
       expect(subject.convert_to(:cm2).quantity).to eq 100_000_000_000
     end
   end
-  
+
   describe 'hectares' do
     subject { described_class.parse('10 ha') }
-    
+
     it 'converts to square kilometers' do
       expect(subject.convert_to(:km2).quantity).to eq 0.1
     end
-    
+
     it 'converts to ares' do
       expect(subject.convert_to(:a).quantity).to eq 1_000
     end
-    
+
     it 'converts to square centimeters' do
       expect(subject.convert_to(:cm2).quantity).to eq 1_000_000_000
     end
   end
-  
+
   describe 'ares' do
     subject { described_class.parse('1000 a') }
-    
+
     it 'converts to square kilometers' do
       expect(subject.convert_to(:km2).quantity).to eq 0.1
     end
-    
+
     it 'converts to hectares' do
       expect(subject.convert_to(:ha).quantity).to eq 10
     end
-    
+
     it 'converts to square centimeters' do
       expect(subject.convert_to(:cm2).quantity).to eq 1_000_000_000
     end
   end
-  
+
   describe 'square centimeters' do
     subject { described_class.parse('10000000000 cm²') }
-    
+
     it 'converts to square kilometers' do
       expect(subject.convert_to(:km2).quantity).to eq 1
     end
-    
+
     it 'converts to hectares' do
       expect(subject.convert_to(:ha).quantity).to eq 100
     end
-    
+
     it 'converts to ares' do
       expect(subject.convert_to(:a).quantity).to eq 10_000
     end

--- a/spec/ruby-measurement/definitions/metric/capacity_spec.rb
+++ b/spec/ruby-measurement/definitions/metric/capacity_spec.rb
@@ -5,35 +5,35 @@ require 'spec_helper'
 RSpec.describe Measurement do
   describe 'cubic meters' do
     subject { described_class.parse('1 m³') }
-    
+
     it 'converts to cubic decimeters' do
       expect(subject.convert_to(:dm3).quantity).to eq 1_000
     end
-    
+
     it 'converts to cubic centimeters' do
       expect(subject.convert_to(:cm3).quantity).to eq 1_000_000
     end
   end
-  
+
   describe 'cubic decimeters' do
     subject { described_class.parse('1000 dm³') }
-    
+
     it 'converts to cubic meters' do
       expect(subject.convert_to(:m3).quantity).to eq 1
     end
-    
+
     it 'converts to cubic centimeters' do
       expect(subject.convert_to(:cm3).quantity).to eq 1_000_000
     end
   end
-  
+
   describe 'cubic centimeters' do
     subject { described_class.parse('1000000 cm³') }
-    
+
     it 'converts to cubic meters' do
       expect(subject.convert_to(:m3).quantity).to eq 1
     end
-    
+
     it 'converts to cubic decimeters' do
       expect(subject.convert_to(:dm3).quantity).to eq 1_000
     end

--- a/spec/ruby-measurement/definitions/metric/length_spec.rb
+++ b/spec/ruby-measurement/definitions/metric/length_spec.rb
@@ -5,255 +5,255 @@ require 'spec_helper'
 RSpec.describe Measurement do
   describe 'kilometers' do
     subject { described_class.parse('1 km') }
-    
+
     it 'converts to hectometers' do
       expect(subject.convert_to(:hm).quantity).to eq 10
     end
-    
+
     it 'converts to dekameters' do
       expect(subject.convert_to(:dam).quantity).to eq 100
     end
-    
+
     it 'converts to meters' do
       expect(subject.convert_to(:m).quantity).to eq 1_000
     end
-    
+
     it 'converts to decimeters' do
       expect(subject.convert_to(:dm).quantity).to eq 10_000
     end
-    
+
     it 'converts to centimeters' do
       expect(subject.convert_to(:cm).quantity).to eq 100_000
     end
-    
+
     it 'converts to millimeters' do
       expect(subject.convert_to(:mm).quantity).to eq 1_000_000
     end
-    
+
     it 'converts to micrometers' do
       expect(subject.convert_to(:µm).quantity).to eq 10_000_000
     end
   end
-  
+
   describe 'hectometers' do
     subject { described_class.parse('10 hm') }
-    
+
     it 'converts to kilometers' do
       expect(subject.convert_to(:km).quantity).to eq 1
     end
-    
+
     it 'converts to dekameters' do
       expect(subject.convert_to(:dam).quantity).to eq 100
     end
-    
+
     it 'converts to meters' do
       expect(subject.convert_to(:m).quantity).to eq 1_000
     end
-    
+
     it 'converts to decimeters' do
       expect(subject.convert_to(:dm).quantity).to eq 10_000
     end
-    
+
     it 'converts to centimeters' do
       expect(subject.convert_to(:cm).quantity).to eq 100_000
     end
-    
+
     it 'converts to millimeters' do
       expect(subject.convert_to(:mm).quantity).to eq 1_000_000
     end
-    
+
     it 'converts to micrometers' do
       expect(subject.convert_to(:µm).quantity).to eq 10_000_000
     end
   end
-  
+
   describe 'dekameters' do
     subject { described_class.parse('100 dam') }
-    
+
     it 'converts to kilometers' do
       expect(subject.convert_to(:km).quantity).to eq 1
     end
-    
+
     it 'converts to hectometers' do
       expect(subject.convert_to(:hm).quantity).to eq 10
     end
-    
+
     it 'converts to meters' do
       expect(subject.convert_to(:m).quantity).to eq 1_000
     end
-    
+
     it 'converts to decimeters' do
       expect(subject.convert_to(:dm).quantity).to eq 10_000
     end
-    
+
     it 'converts to centimeters' do
       expect(subject.convert_to(:cm).quantity).to eq 100_000
     end
-    
+
     it 'converts to millimeters' do
       expect(subject.convert_to(:mm).quantity).to eq 1_000_000
     end
-    
+
     it 'converts to micrometers' do
       expect(subject.convert_to(:µm).quantity).to eq 10_000_000
     end
   end
-  
+
   describe 'meters' do
     subject { described_class.parse('1000 m') }
-    
+
     it 'converts to kilometers' do
       expect(subject.convert_to(:km).quantity).to eq 1
     end
-    
+
     it 'converts to hectometers' do
       expect(subject.convert_to(:hm).quantity).to eq 10
     end
-    
+
     it 'converts to dekameters' do
       expect(subject.convert_to(:dam).quantity).to eq 100
     end
-    
+
     it 'converts to decimeters' do
       expect(subject.convert_to(:dm).quantity).to eq 10_000
     end
-    
+
     it 'converts to centimeters' do
       expect(subject.convert_to(:cm).quantity).to eq 100_000
     end
-    
+
     it 'converts to millimeters' do
       expect(subject.convert_to(:mm).quantity).to eq 1_000_000
     end
-    
+
     it 'converts to micrometers' do
       expect(subject.convert_to(:µm).quantity).to eq 10_000_000
     end
   end
-  
+
   describe 'decimeters' do
     subject { described_class.parse('10000 dm') }
-    
+
     it 'converts to kilometers' do
       expect(subject.convert_to(:km).quantity).to eq 1
     end
-    
+
     it 'converts to hectometers' do
       expect(subject.convert_to(:hm).quantity).to eq 10
     end
-    
+
     it 'converts to dekameters' do
       expect(subject.convert_to(:dam).quantity).to eq 100
     end
-    
+
     it 'converts to meters' do
       expect(subject.convert_to(:m).quantity).to eq 1_000
     end
-    
+
     it 'converts to centimeters' do
       expect(subject.convert_to(:cm).quantity).to eq 100_000
     end
-    
+
     it 'converts to millimeters' do
       expect(subject.convert_to(:mm).quantity).to eq 1_000_000
     end
-    
+
     it 'converts to micrometers' do
       expect(subject.convert_to(:µm).quantity).to eq 10_000_000
     end
   end
-  
+
   describe 'centimeters' do
     subject { described_class.parse('100000 cm') }
-    
+
     it 'converts to kilometers' do
       expect(subject.convert_to(:km).quantity).to eq 1
     end
-    
+
     it 'converts to hectoliters' do
       expect(subject.convert_to(:hm).quantity).to eq 10
     end
-    
+
     it 'converts to dekameters' do
       expect(subject.convert_to(:dam).quantity).to eq 100
     end
-    
+
     it 'converts to meters' do
       expect(subject.convert_to(:m).quantity).to eq 1_000
     end
-    
+
     it 'converts to decimeters' do
       expect(subject.convert_to(:dm).quantity).to eq 10_000
     end
-    
+
     it 'converts to millimeters' do
       expect(subject.convert_to(:mm).quantity).to eq 1_000_000
     end
-    
+
     it 'converts to micrometers' do
       expect(subject.convert_to(:µm).quantity).to eq 10_000_000
     end
   end
-  
+
   describe 'millimeters' do
     subject { described_class.parse('1000000 mm') }
-    
+
     it 'converts to kilometers' do
       expect(subject.convert_to(:km).quantity).to eq 1
     end
-    
+
     it 'converts to hectometers' do
       expect(subject.convert_to(:hm).quantity).to eq 10
     end
-    
+
     it 'converts to dekameters' do
       expect(subject.convert_to(:dam).quantity).to eq 100
     end
-    
+
     it 'converts to meters' do
       expect(subject.convert_to(:m).quantity).to eq 1_000
     end
-    
+
     it 'converts to decimeters' do
       expect(subject.convert_to(:dm).quantity).to eq 10_000
     end
-    
+
     it 'converts to centimeters' do
       expect(subject.convert_to(:cm).quantity).to eq 100_000
     end
-    
+
     it 'converts to micrometers' do
       expect(subject.convert_to(:µm).quantity).to eq 10_000_000
     end
   end
-  
+
   describe 'micrometers' do
     subject { described_class.parse('10000000 µm') }
-    
+
     it 'converts to kilometers' do
       expect(subject.convert_to(:km).quantity).to eq 1
     end
-    
+
     it 'converts to hectometers' do
       expect(subject.convert_to(:hm).quantity).to eq 10
     end
-    
+
     it 'converts to dekameters' do
       expect(subject.convert_to(:dam).quantity).to eq 100
     end
-    
+
     it 'converts to meters' do
       expect(subject.convert_to(:m).quantity).to eq 1_000
     end
-    
+
     it 'converts to decimeters' do
       expect(subject.convert_to(:dm).quantity).to eq 10_000
     end
-    
+
     it 'converts to centimeters' do
       expect(subject.convert_to(:cm).quantity).to eq 100_000
     end
-    
+
     it 'converts to millimeters' do
       expect(subject.convert_to(:mm).quantity).to eq 1_000_000
     end

--- a/spec/ruby-measurement/definitions/metric/volume_spec.rb
+++ b/spec/ruby-measurement/definitions/metric/volume_spec.rb
@@ -5,255 +5,255 @@ require 'spec_helper'
 RSpec.describe Measurement do
   describe 'kiloliters' do
     subject { described_class.parse('1 kl') }
-    
+
     it 'converts to hectoliters' do
       expect(subject.convert_to(:hl).quantity).to eq 10
     end
-    
+
     it 'converts to dekaliters' do
       expect(subject.convert_to(:dal).quantity).to eq 100
     end
-    
+
     it 'converts to liters' do
       expect(subject.convert_to(:l).quantity).to eq 1_000
     end
-    
+
     it 'converts to deciliters' do
       expect(subject.convert_to(:dl).quantity).to eq 10_000
     end
-    
+
     it 'converts to centiliters' do
       expect(subject.convert_to(:cl).quantity).to eq 100_000
     end
-    
+
     it 'converts to milliliters' do
       expect(subject.convert_to(:ml).quantity).to eq 1_000_000
     end
-    
+
     it 'converts to microliters' do
       expect(subject.convert_to(:µl).quantity).to eq 10_000_000
     end
   end
-  
+
   describe 'hectoliters' do
     subject { described_class.parse('10 hl') }
-    
+
     it 'converts to kiloliters' do
       expect(subject.convert_to(:kl).quantity).to eq 1
     end
-    
+
     it 'converts to dekaliters' do
       expect(subject.convert_to(:dal).quantity).to eq 100
     end
-    
+
     it 'converts to liters' do
       expect(subject.convert_to(:l).quantity).to eq 1_000
     end
-    
+
     it 'converts to deciliters' do
       expect(subject.convert_to(:dl).quantity).to eq 10_000
     end
-    
+
     it 'converts to centiliters' do
       expect(subject.convert_to(:cl).quantity).to eq 100_000
     end
-    
+
     it 'converts to milliliters' do
       expect(subject.convert_to(:ml).quantity).to eq 1_000_000
     end
-    
+
     it 'converts to microliters' do
       expect(subject.convert_to(:µl).quantity).to eq 10_000_000
     end
   end
-  
+
   describe 'dekaliters' do
     subject { described_class.parse('100 dal') }
-    
+
     it 'converts to kiloliters' do
       expect(subject.convert_to(:kl).quantity).to eq 1
     end
-    
+
     it 'converts to hectoliters' do
       expect(subject.convert_to(:hl).quantity).to eq 10
     end
-    
+
     it 'converts to liters' do
       expect(subject.convert_to(:l).quantity).to eq 1_000
     end
-    
+
     it 'converts to deciliters' do
       expect(subject.convert_to(:dl).quantity).to eq 10_000
     end
-    
+
     it 'converts to centiliters' do
       expect(subject.convert_to(:cl).quantity).to eq 100_000
     end
-    
+
     it 'converts to milliliters' do
       expect(subject.convert_to(:ml).quantity).to eq 1_000_000
     end
-    
+
     it 'converts to microliters' do
       expect(subject.convert_to(:µl).quantity).to eq 10_000_000
     end
   end
-  
+
   describe 'liters' do
     subject { described_class.parse('1000 l') }
-    
+
     it 'converts to kiloliters' do
       expect(subject.convert_to(:kl).quantity).to eq 1
     end
-    
+
     it 'converts to hectoliters' do
       expect(subject.convert_to(:hl).quantity).to eq 10
     end
-    
+
     it 'converts to dekaliters' do
       expect(subject.convert_to(:dal).quantity).to eq 100
     end
-    
+
     it 'converts to deciliters' do
       expect(subject.convert_to(:dl).quantity).to eq 10_000
     end
-    
+
     it 'converts to centiliters' do
       expect(subject.convert_to(:cl).quantity).to eq 100_000
     end
-    
+
     it 'converts to milliliters' do
       expect(subject.convert_to(:ml).quantity).to eq 1_000_000
     end
-    
+
     it 'converts to microliters' do
       expect(subject.convert_to(:µl).quantity).to eq 10_000_000
     end
   end
-  
+
   describe 'deciliters' do
     subject { described_class.parse('10000 dl') }
-    
+
     it 'converts to kiloliters' do
       expect(subject.convert_to(:kl).quantity).to eq 1
     end
-    
+
     it 'converts to hectoliters' do
       expect(subject.convert_to(:hl).quantity).to eq 10
     end
-    
+
     it 'converts to dekaliters' do
       expect(subject.convert_to(:dal).quantity).to eq 100
     end
-    
+
     it 'converts to liters' do
       expect(subject.convert_to(:l).quantity).to eq 1_000
     end
-    
+
     it 'converts to centiliters' do
       expect(subject.convert_to(:cl).quantity).to eq 100_000
     end
-    
+
     it 'converts to milliliters' do
       expect(subject.convert_to(:ml).quantity).to eq 1_000_000
     end
-    
+
     it 'converts to microliters' do
       expect(subject.convert_to(:µl).quantity).to eq 10_000_000
     end
   end
-  
+
   describe 'centiliters' do
     subject { described_class.parse('100000 cl') }
-    
+
     it 'converts to kiloliters' do
       expect(subject.convert_to(:kl).quantity).to eq 1
     end
-    
+
     it 'converts to hectoliters' do
       expect(subject.convert_to(:hl).quantity).to eq 10
     end
-    
+
     it 'converts to dekaliters' do
       expect(subject.convert_to(:dal).quantity).to eq 100
     end
-    
+
     it 'converts to liters' do
       expect(subject.convert_to(:l).quantity).to eq 1_000
     end
-    
+
     it 'converts to deciliters' do
       expect(subject.convert_to(:dl).quantity).to eq 10_000
     end
-    
+
     it 'converts to milliliters' do
       expect(subject.convert_to(:ml).quantity).to eq 1_000_000
     end
-    
+
     it 'converts to microliters' do
       expect(subject.convert_to(:µl).quantity).to eq 10_000_000
     end
   end
-  
+
   describe 'milliliters' do
     subject { described_class.parse('1000000 ml') }
-    
+
     it 'converts to kiloliters' do
       expect(subject.convert_to(:kl).quantity).to eq 1
     end
-    
+
     it 'converts to hectoliters' do
       expect(subject.convert_to(:hl).quantity).to eq 10
     end
-    
+
     it 'converts to dekaliters' do
       expect(subject.convert_to(:dal).quantity).to eq 100
     end
-    
+
     it 'converts to liters' do
       expect(subject.convert_to(:l).quantity).to eq 1_000
     end
-    
+
     it 'converts to deciliters' do
       expect(subject.convert_to(:dl).quantity).to eq 10_000
     end
-    
+
     it 'converts to centiliters' do
       expect(subject.convert_to(:cl).quantity).to eq 100_000
     end
-    
+
     it 'converts to microliters' do
       expect(subject.convert_to(:µl).quantity).to eq 10_000_000
     end
   end
-  
+
   describe 'microliters' do
     subject { described_class.parse('10000000 µl') }
-    
+
     it 'converts to kiloliters' do
       expect(subject.convert_to(:kl).quantity).to eq 1
     end
-    
+
     it 'converts to hectoliters' do
       expect(subject.convert_to(:hl).quantity).to eq 10
     end
-    
+
     it 'converts to dekaliters' do
       expect(subject.convert_to(:dal).quantity).to eq 100
     end
-    
+
     it 'converts to liters' do
       expect(subject.convert_to(:l).quantity).to eq 1_000
     end
-    
+
     it 'converts to deciliters' do
       expect(subject.convert_to(:dl).quantity).to eq 10_000
     end
-    
+
     it 'converts to centiliters' do
       expect(subject.convert_to(:cl).quantity).to eq 100_000
     end
-    
+
     it 'converts to milliliters' do
       expect(subject.convert_to(:ml).quantity).to eq 1_000_000
     end

--- a/spec/ruby-measurement/definitions/metric/weight_spec.rb
+++ b/spec/ruby-measurement/definitions/metric/weight_spec.rb
@@ -5,319 +5,319 @@ require 'spec_helper'
 RSpec.describe Measurement do
   describe 'tonnes' do
     subject { described_class.parse('0.001 tonne') }
-    
+
     it 'converts to hectograms' do
       expect(subject.convert_to(:hg).quantity).to eq 10
     end
-    
+
     it 'converts to dekagrams' do
       expect(subject.convert_to(:dag).quantity).to eq 100
     end
-    
+
     it 'converts to grams' do
       expect(subject.convert_to(:g).quantity).to eq 1_000
     end
-    
+
     it 'converts to decigrams' do
       expect(subject.convert_to(:dg).quantity).to eq 10_000
     end
-    
+
     it 'converts to centigrams' do
       expect(subject.convert_to(:cg).quantity).to eq 100_000
     end
-    
+
     it 'converts to milligrams' do
       expect(subject.convert_to(:mg).quantity).to eq 1_000_000
     end
-    
+
     it 'converts to micrograms' do
       expect(subject.convert_to(:µg).quantity).to eq 10_000_000
     end
   end
-  
+
   describe 'kilograms' do
     subject { described_class.parse('1 kg') }
-    
+
     it 'converts to tonnes' do
       expect(subject.convert_to(:t).quantity).to eq 0.001
     end
-    
+
     it 'converts to hectograms' do
       expect(subject.convert_to(:hg).quantity).to eq 10
     end
-    
+
     it 'converts to dekagrams' do
       expect(subject.convert_to(:dag).quantity).to eq 100
     end
-    
+
     it 'converts to grams' do
       expect(subject.convert_to(:g).quantity).to eq 1_000
     end
-    
+
     it 'converts to decigrams' do
       expect(subject.convert_to(:dg).quantity).to eq 10_000
     end
-    
+
     it 'converts to centigrams' do
       expect(subject.convert_to(:cg).quantity).to eq 100_000
     end
-    
+
     it 'converts to milligrams' do
       expect(subject.convert_to(:mg).quantity).to eq 1_000_000
     end
-    
+
     it 'converts to micrograms' do
       expect(subject.convert_to(:µg).quantity).to eq 10_000_000
     end
   end
-  
+
   describe 'hectograms' do
     subject { described_class.parse('10 hg') }
-    
+
     it 'converts to tonnes' do
       expect(subject.convert_to(:t).quantity).to eq 0.001
     end
-    
+
     it 'converts to kilograms' do
       expect(subject.convert_to(:kg).quantity).to eq 1
     end
-    
+
     it 'converts to dekagrams' do
       expect(subject.convert_to(:dag).quantity).to eq 100
     end
-    
+
     it 'converts to grams' do
       expect(subject.convert_to(:g).quantity).to eq 1_000
     end
-    
+
     it 'converts to decigrams' do
       expect(subject.convert_to(:dg).quantity).to eq 10_000
     end
-    
+
     it 'converts to centigrams' do
       expect(subject.convert_to(:cg).quantity).to eq 100_000
     end
-    
+
     it 'converts to milligrams' do
       expect(subject.convert_to(:mg).quantity).to eq 1_000_000
     end
-    
+
     it 'converts to micrograms' do
       expect(subject.convert_to(:µg).quantity).to eq 10_000_000
     end
   end
-  
+
   describe 'dekagrams' do
     subject { described_class.parse('100 dag') }
-    
+
     it 'converts to tonnes' do
       expect(subject.convert_to(:t).quantity).to eq 0.001
     end
-    
+
     it 'converts to kilograms' do
       expect(subject.convert_to(:kg).quantity).to eq 1
     end
-    
+
     it 'converts to hectograms' do
       expect(subject.convert_to(:hg).quantity).to eq 10
     end
-    
+
     it 'converts to grams' do
       expect(subject.convert_to(:g).quantity).to eq 1_000
     end
-    
+
     it 'converts to decigrams' do
       expect(subject.convert_to(:dg).quantity).to eq 10_000
     end
-    
+
     it 'converts to centigrams' do
       expect(subject.convert_to(:cg).quantity).to eq 100_000
     end
-    
+
     it 'converts to milligrams' do
       expect(subject.convert_to(:mg).quantity).to eq 1_000_000
     end
-    
+
     it 'converts to micrograms' do
       expect(subject.convert_to(:µg).quantity).to eq 10_000_000
     end
   end
-  
+
   describe 'grams' do
     subject { described_class.parse('1000 g') }
-    
+
     it 'converts to tonnes' do
       expect(subject.convert_to(:t).quantity).to eq 0.001
     end
-    
+
     it 'converts to kilograms' do
       expect(subject.convert_to(:kg).quantity).to eq 1
     end
-    
+
     it 'converts to hectograms' do
       expect(subject.convert_to(:hg).quantity).to eq 10
     end
-    
+
     it 'converts to dekagrams' do
       expect(subject.convert_to(:dag).quantity).to eq 100
     end
-    
+
     it 'converts to decigrams' do
       expect(subject.convert_to(:dg).quantity).to eq 10_000
     end
-    
+
     it 'converts to centigrams' do
       expect(subject.convert_to(:cg).quantity).to eq 100_000
     end
-    
+
     it 'converts to milligrams' do
       expect(subject.convert_to(:mg).quantity).to eq 1_000_000
     end
-    
+
     it 'converts to micrograms' do
       expect(subject.convert_to(:µg).quantity).to eq 10_000_000
     end
   end
-  
+
   describe 'decigrams' do
     subject { described_class.parse('10000 dg') }
-    
+
     it 'converts to tonnes' do
       expect(subject.convert_to(:t).quantity).to eq 0.001
     end
-    
+
     it 'converts to kilograms' do
       expect(subject.convert_to(:kg).quantity).to eq 1
     end
-    
+
     it 'converts to hectograms' do
       expect(subject.convert_to(:hg).quantity).to eq 10
     end
-    
+
     it 'converts to dekagrams' do
       expect(subject.convert_to(:dag).quantity).to eq 100
     end
-    
+
     it 'converts to grams' do
       expect(subject.convert_to(:g).quantity).to eq 1_000
     end
-    
+
     it 'converts to centigrams' do
       expect(subject.convert_to(:cg).quantity).to eq 100_000
     end
-    
+
     it 'converts to milligrams' do
       expect(subject.convert_to(:mg).quantity).to eq 1_000_000
     end
-    
+
     it 'converts to micrograms' do
       expect(subject.convert_to(:µg).quantity).to eq 10_000_000
     end
   end
-  
+
   describe 'centigrams' do
     subject { described_class.parse('100000 cg') }
-    
+
     it 'converts to tonnes' do
       expect(subject.convert_to(:t).quantity).to eq 0.001
     end
-    
+
     it 'converts to kilograms' do
       expect(subject.convert_to(:kg).quantity).to eq 1
     end
-    
+
     it 'converts to hectograms' do
       expect(subject.convert_to(:hg).quantity).to eq 10
     end
-    
+
     it 'converts to dekagrams' do
       expect(subject.convert_to(:dag).quantity).to eq 100
     end
-    
+
     it 'converts to grams' do
       expect(subject.convert_to(:g).quantity).to eq 1_000
     end
-    
+
     it 'converts to decigrams' do
       expect(subject.convert_to(:dg).quantity).to eq 10_000
     end
-    
+
     it 'converts to milligrams' do
       expect(subject.convert_to(:mg).quantity).to eq 1_000_000
     end
-    
+
     it 'converts to micrograms' do
       expect(subject.convert_to(:µg).quantity).to eq 10_000_000
     end
   end
-  
+
   describe 'milligrams' do
     subject { described_class.parse('1000000 mg') }
-    
+
     it 'converts to tonnes' do
       expect(subject.convert_to(:t).quantity).to eq 0.001
     end
-    
+
     it 'converts to kilograms' do
       expect(subject.convert_to(:kg).quantity).to eq 1
     end
-    
+
     it 'converts to hectograms' do
       expect(subject.convert_to(:hg).quantity).to eq 10
     end
-    
+
     it 'converts to dekagrams' do
       expect(subject.convert_to(:dag).quantity).to eq 100
     end
-    
+
     it 'converts to grams' do
       expect(subject.convert_to(:g).quantity).to eq 1_000
     end
-    
+
     it 'converts to decigrams' do
       expect(subject.convert_to(:dg).quantity).to eq 10_000
     end
-    
+
     it 'converts to centigrams' do
       expect(subject.convert_to(:cg).quantity).to eq 100_000
     end
-    
+
     it 'converts to micrograms' do
       expect(subject.convert_to(:µg).quantity).to eq 10_000_000
     end
   end
-  
+
   describe 'micrograms' do
     subject { described_class.parse('10000000 µg') }
-    
+
     it 'converts to tonnes' do
       expect(subject.convert_to(:t).quantity).to eq 0.001
     end
-    
+
     it 'converts to kilograms' do
       expect(subject.convert_to(:kg).quantity).to eq 1
     end
-    
+
     it 'converts to hectograms' do
       expect(subject.convert_to(:hg).quantity).to eq 10
     end
-    
+
     it 'converts to dekagrams' do
       expect(subject.convert_to(:dag).quantity).to eq 100
     end
-    
+
     it 'converts to grams' do
       expect(subject.convert_to(:g).quantity).to eq 1_000
     end
-    
+
     it 'converts to decigrams' do
       expect(subject.convert_to(:dg).quantity).to eq 10_000
     end
-    
+
     it 'converts to centigrams' do
       expect(subject.convert_to(:cg).quantity).to eq 100_000
     end
-    
+
     it 'converts to milligrams' do
       expect(subject.convert_to(:mg).quantity).to eq 1_000_000
     end

--- a/spec/ruby-measurement/definitions/us_customary/area_spec.rb
+++ b/spec/ruby-measurement/definitions/us_customary/area_spec.rb
@@ -5,143 +5,143 @@ require 'spec_helper'
 RSpec.describe Measurement do
   describe 'square miles' do
     subject { described_class.parse('1 mi²') }
-    
+
     it 'converts to square furlongs' do
       expect(subject.convert_to(:fur2).quantity).to eq 64
     end
-    
+
     it 'converts to square chains' do
       expect(subject.convert_to(:ch2).quantity).to eq 6_400
     end
-    
+
     it 'converts to square yards' do
       expect(subject.convert_to(:yd2).quantity).to eq 3_097_600
     end
-    
+
     it 'converts to square feet' do
       expect(subject.convert_to(:ft2).quantity).to eq 27_878_400
     end
-    
+
     it 'converts to square inches' do
       expect(subject.convert_to(:in2).quantity).to eq 4_014_489_600
     end
   end
-  
+
   describe 'square furlongs' do
     subject { described_class.parse('64 fur²') }
-    
+
     it 'converts to square miles' do
       expect(subject.convert_to(:mi2).quantity).to eq 1
     end
-    
+
     it 'converts to square chains' do
       expect(subject.convert_to(:ch2).quantity).to eq 6_400
     end
-    
+
     it 'converts to square yards' do
       expect(subject.convert_to(:yd2).quantity).to eq 3_097_600
     end
-    
+
     it 'converts to square feet' do
       expect(subject.convert_to(:ft2).quantity).to eq 27_878_400
     end
-    
+
     it 'converts to square inches' do
       expect(subject.convert_to(:in2).quantity).to eq 4_014_489_600
     end
   end
-  
+
   describe 'square chains' do
     subject { described_class.parse('6400 ch²') }
-    
+
     it 'converts to square miles' do
       expect(subject.convert_to(:mi2).quantity).to eq 1
     end
-    
+
     it 'converts to square furlongs' do
       expect(subject.convert_to(:fur2).quantity).to eq 64
     end
-    
+
     it 'converts to square yards' do
       expect(subject.convert_to(:yd2).quantity).to eq 3_097_600
     end
-    
+
     it 'converts to square feet' do
       expect(subject.convert_to(:ft2).quantity).to eq 27_878_400
     end
-    
+
     it 'converts to square inches' do
       expect(subject.convert_to(:in2).quantity).to eq 4_014_489_600
     end
   end
-  
+
   describe 'square yards' do
     subject { described_class.parse('3097600 yd²') }
-    
+
     it 'converts to square miles' do
       expect(subject.convert_to(:mi2).quantity).to eq 1
     end
-    
+
     it 'converts to square furlongs' do
       expect(subject.convert_to(:fur2).quantity).to eq 64
     end
-    
+
     it 'converts to square chains' do
       expect(subject.convert_to(:ch2).quantity).to eq 6_400
     end
-    
+
     it 'converts to square feet' do
       expect(subject.convert_to(:ft2).quantity).to eq 27_878_400
     end
-    
+
     it 'converts to square inches' do
       expect(subject.convert_to(:in2).quantity).to eq 4_014_489_600
     end
   end
-  
+
   describe 'square feet' do
     subject { described_class.parse('27878400 ft²') }
-    
+
     it 'converts to square miles' do
       expect(subject.convert_to(:mi2).quantity).to eq 1
     end
-    
+
     it 'converts to square furlongs' do
       expect(subject.convert_to(:fur2).quantity).to eq 64
     end
-    
+
     it 'converts to square chains' do
       expect(subject.convert_to(:ch2).quantity).to eq 6_400
     end
-    
+
     it 'converts to square yards' do
       expect(subject.convert_to(:yd2).quantity).to eq 3_097_600
     end
-    
+
     it 'converts to square inches' do
       expect(subject.convert_to(:in2).quantity).to eq 4_014_489_600
     end
   end
-  
+
   describe 'square inches' do
     subject { described_class.parse('4014489600 in²') }
-    
+
     it 'converts to square miles' do
       expect(subject.convert_to(:mi2).quantity).to eq 1
     end
-    
+
     it 'converts to square furlongs' do
       expect(subject.convert_to(:fur2).quantity).to eq 64
     end
-    
+
     it 'converts to square chains' do
       expect(subject.convert_to(:ch2).quantity).to eq 6_400
     end
-    
+
     it 'converts to square yards' do
       expect(subject.convert_to(:yd2).quantity).to eq 3_097_600
     end
-    
+
     it 'converts to square feet' do
       expect(subject.convert_to(:ft2).quantity).to eq 27_878_400
     end

--- a/spec/ruby-measurement/definitions/us_customary/capacity_spec.rb
+++ b/spec/ruby-measurement/definitions/us_customary/capacity_spec.rb
@@ -5,63 +5,63 @@ require 'spec_helper'
 RSpec.describe Measurement do
   describe 'acre-feet' do
     subject { described_class.parse('1 acre ft') }
-    
+
     it 'converts to cubic yards' do
       expect(subject.convert_to(:yd3).quantity).to eq Rational(4840, 3).to_f
     end
-    
+
     it 'converts to cubic feet' do
       expect(subject.convert_to(:ft3).quantity).to eq 43_560
     end
-    
+
     it 'converts to cubic inches' do
       expect(subject.convert_to(:in3).quantity).to eq 75_271_680
     end
   end
-  
+
   describe 'cubic yards' do
     subject { described_class.parse('1613 1/3 yd³') }
-    
+
     it 'converts to acre-feet' do
       expect(subject.convert_to(:'acre ft').quantity).to eq 1
     end
-    
+
     it 'converts to cubic feet' do
       expect(subject.convert_to(:ft3).quantity).to eq 43_560
     end
-    
+
     it 'converts to cubic inches' do
       expect(subject.convert_to(:in3).quantity).to eq 75_271_680
     end
   end
-  
+
   describe 'cubic feet' do
     subject { described_class.parse('43560 ft³') }
-    
+
     it 'converts to acre-feet' do
       expect(subject.convert_to(:'acre ft').quantity).to eq 1
     end
-    
+
     it 'converts to cubic yards' do
       expect(subject.convert_to(:yd3).quantity).to eq Rational(4840, 3).to_f
     end
-    
+
     it 'converts to cubic inches' do
       expect(subject.convert_to(:in3).quantity).to eq 75_271_680
     end
   end
-  
+
   describe 'cubic inches' do
     subject { described_class.parse('75271680 in³') }
-    
+
     it 'converts to acre-feet' do
       expect(subject.convert_to(:'acre ft').quantity).to eq 1
     end
-    
+
     it 'converts to cubic yards' do
       expect(subject.convert_to(:yd3).quantity).to eq Rational(4840, 3).to_f
     end
-    
+
     it 'converts to cubic feet' do
       expect(subject.convert_to(:ft3).quantity).to eq 43_560
     end

--- a/spec/ruby-measurement/definitions/us_customary/length_spec.rb
+++ b/spec/ruby-measurement/definitions/us_customary/length_spec.rb
@@ -5,255 +5,255 @@ require 'spec_helper'
 RSpec.describe Measurement do
   describe 'miles' do
     subject { described_class.parse('1 mi') }
-    
+
     it 'converts to furlongs' do
       expect(subject.convert_to(:fur).quantity).to eq 8
     end
-    
+
     it 'converts to chains' do
       expect(subject.convert_to(:ch).quantity).to eq 80
     end
-    
+
     it 'converts to fathoms' do
       expect(subject.convert_to(:ftm).quantity).to eq 880
     end
-    
+
     it 'converts to yards' do
       expect(subject.convert_to(:yd).quantity).to eq 1_760
     end
-    
+
     it 'converts to feet' do
       expect(subject.convert_to(:ft).quantity).to eq 5_280
     end
-    
+
     it 'converts to inches' do
       expect(subject.convert_to(:in).quantity).to eq 63_360
     end
-    
+
     it 'converts to thou' do
       expect(subject.convert_to(:th).quantity).to eq 63_360_000
     end
   end
-  
+
   describe 'furlongs' do
     subject { described_class.parse('8 fur') }
-    
+
     it 'converts to miles' do
       expect(subject.convert_to(:mi).quantity).to eq 1
     end
-    
+
     it 'converts to chains' do
       expect(subject.convert_to(:ch).quantity).to eq 80
     end
-    
+
     it 'converts to fathoms' do
       expect(subject.convert_to(:ftm).quantity).to eq 880
     end
-    
+
     it 'converts to yards' do
       expect(subject.convert_to(:yd).quantity).to eq 1_760
     end
-    
+
     it 'converts to feet' do
       expect(subject.convert_to(:ft).quantity).to eq 5_280
     end
-    
+
     it 'converts to inches' do
       expect(subject.convert_to(:in).quantity).to eq 63_360
     end
-    
+
     it 'converts to thou' do
       expect(subject.convert_to(:th).quantity).to eq 63_360_000
     end
   end
-  
+
   describe 'chains' do
     subject { described_class.parse('80 ch') }
-    
+
     it 'converts to miles' do
       expect(subject.convert_to(:mi).quantity).to eq 1
     end
-    
+
     it 'converts to furlongs' do
       expect(subject.convert_to(:fur).quantity).to eq 8
     end
-    
+
     it 'converts to fathoms' do
       expect(subject.convert_to(:ftm).quantity).to eq 880
     end
-    
+
     it 'converts to yards' do
       expect(subject.convert_to(:yd).quantity).to eq 1_760
     end
-    
+
     it 'converts to feet' do
       expect(subject.convert_to(:ft).quantity).to eq 5_280
     end
-    
+
     it 'converts to inches' do
       expect(subject.convert_to(:in).quantity).to eq 63_360
     end
-    
+
     it 'converts to thou' do
       expect(subject.convert_to(:th).quantity).to eq 63_360_000
     end
   end
-  
+
   describe 'fathoms' do
     subject { described_class.parse('880 ftm') }
-    
+
     it 'converts to miles' do
       expect(subject.convert_to(:mi).quantity).to eq 1
     end
-    
+
     it 'converts to furlongs' do
       expect(subject.convert_to(:fur).quantity).to eq 8
     end
-    
+
     it 'converts to chains' do
       expect(subject.convert_to(:ch).quantity).to eq 80
     end
-    
+
     it 'converts to yards' do
       expect(subject.convert_to(:yd).quantity).to eq 1_760
     end
-    
+
     it 'converts to feet' do
       expect(subject.convert_to(:ft).quantity).to eq 5_280
     end
-    
+
     it 'converts to inches' do
       expect(subject.convert_to(:in).quantity).to eq 63_360
     end
-    
+
     it 'converts to thou' do
       expect(subject.convert_to(:th).quantity).to eq 63_360_000
     end
   end
-  
+
   describe 'yards' do
     subject { described_class.parse('1760 yd') }
-    
+
     it 'converts to miles' do
       expect(subject.convert_to(:mi).quantity).to eq 1
     end
-    
+
     it 'converts to furlongs' do
       expect(subject.convert_to(:fur).quantity).to eq 8
     end
-    
+
     it 'converts to chains' do
       expect(subject.convert_to(:ch).quantity).to eq 80
     end
-    
+
     it 'converts to fathoms' do
       expect(subject.convert_to(:ftm).quantity).to eq 880
     end
-    
+
     it 'converts to feet' do
       expect(subject.convert_to(:ft).quantity).to eq 5_280
     end
-    
+
     it 'converts to inches' do
       expect(subject.convert_to(:in).quantity).to eq 63_360
     end
-    
+
     it 'converts to thou' do
       expect(subject.convert_to(:th).quantity).to eq 63_360_000
     end
   end
-  
+
   describe 'feet' do
     subject { described_class.parse('5280 ft') }
-    
+
     it 'converts to miles' do
       expect(subject.convert_to(:mi).quantity).to eq 1
     end
-    
+
     it 'converts to furlongs' do
       expect(subject.convert_to(:fur).quantity).to eq 8
     end
-    
+
     it 'converts to chains' do
       expect(subject.convert_to(:ch).quantity).to eq 80
     end
-    
+
     it 'converts to fathoms' do
       expect(subject.convert_to(:ftm).quantity).to eq 880
     end
-    
+
     it 'converts to yards' do
       expect(subject.convert_to(:yd).quantity).to eq 1_760
     end
-    
+
     it 'converts to inches' do
       expect(subject.convert_to(:in).quantity).to eq 63_360
     end
-    
+
     it 'converts to thou' do
       expect(subject.convert_to(:th).quantity).to eq 63_360_000
     end
   end
-  
+
   describe 'inches' do
     subject { described_class.parse('63360 in') }
-    
+
     it 'converts to miles' do
       expect(subject.convert_to(:mi).quantity).to eq 1
     end
-    
+
     it 'converts to furlongs' do
       expect(subject.convert_to(:fur).quantity).to eq 8
     end
-    
+
     it 'converts to chains' do
       expect(subject.convert_to(:ch).quantity).to eq 80
     end
-    
+
     it 'converts to fathoms' do
       expect(subject.convert_to(:ftm).quantity).to eq 880
     end
-    
+
     it 'converts to yards' do
       expect(subject.convert_to(:yd).quantity).to eq 1_760
     end
-    
+
     it 'converts to feet' do
       expect(subject.convert_to(:ft).quantity).to eq 5_280
     end
-    
+
     it 'converts to thou' do
       expect(subject.convert_to(:th).quantity).to eq 63_360_000
     end
   end
-  
+
   describe 'thou' do
     subject { described_class.parse('63360000 th') }
-    
+
     it 'converts to miles' do
       expect(subject.convert_to(:mi).quantity).to eq 1
     end
-    
+
     it 'converts to furlongs' do
       expect(subject.convert_to(:fur).quantity).to eq 8
     end
-    
+
     it 'converts to chains' do
       expect(subject.convert_to(:ch).quantity).to eq 80
     end
-    
+
     it 'converts to fathoms' do
       expect(subject.convert_to(:ftm).quantity).to eq 880
     end
-    
+
     it 'converts to yards' do
       expect(subject.convert_to(:yd).quantity).to eq 1_760
     end
-    
+
     it 'converts to feet' do
       expect(subject.convert_to(:ft).quantity).to eq 5_280
     end
-    
+
     it 'converts to inches' do
       expect(subject.convert_to(:in).quantity).to eq 63_360
     end

--- a/spec/ruby-measurement/definitions/us_customary/volume_spec.rb
+++ b/spec/ruby-measurement/definitions/us_customary/volume_spec.rb
@@ -5,195 +5,195 @@ require 'spec_helper'
 RSpec.describe Measurement do
   describe 'gallons' do
     subject { described_class.parse('1 gal') }
-    
+
     it 'converts to quarts' do
       expect(subject.convert_to(:qt).quantity).to eq 4
     end
-    
+
     it 'converts to pints' do
       expect(subject.convert_to(:pt).quantity).to eq 8
     end
-    
+
     it 'converts to cups' do
       expect(subject.convert_to(:c).quantity).to eq 16
     end
-    
+
     it 'converts to fluid ounces' do
       expect(subject.convert_to(:'fl oz').quantity).to eq 128
     end
-    
+
     it 'converts to tablespoons' do
       expect(subject.convert_to(:tbsp).quantity).to eq 256
     end
-    
+
     it 'converts to teaspoons' do
       expect(subject.convert_to(:tsp).quantity).to eq 768
     end
   end
-  
+
   describe 'quarts' do
     subject { described_class.parse('4 qt') }
-    
+
     it 'converts to gallons' do
       expect(subject.convert_to(:gal).quantity).to eq 1
     end
-    
+
     it 'converts to pints' do
       expect(subject.convert_to(:pt).quantity).to eq 8
     end
-    
+
     it 'converts to cups' do
       expect(subject.convert_to(:c).quantity).to eq 16
     end
-    
+
     it 'converts to fluid ounces' do
       expect(subject.convert_to(:'fl oz').quantity).to eq 128
     end
-    
+
     it 'converts to tablespoons' do
       expect(subject.convert_to(:tbsp).quantity).to eq 256
     end
-    
+
     it 'converts to teaspoons' do
       expect(subject.convert_to(:tsp).quantity).to eq 768
     end
   end
-  
+
   describe 'pints' do
     subject { described_class.parse('8 pt') }
-    
+
     it 'converts to gallons' do
       expect(subject.convert_to(:gal).quantity).to eq 1
     end
-    
+
     it 'converts to quarts' do
       expect(subject.convert_to(:qt).quantity).to eq 4
     end
-    
+
     it 'converts to cups' do
       expect(subject.convert_to(:c).quantity).to eq 16
     end
-    
+
     it 'converts to fluid ounces' do
       expect(subject.convert_to(:'fl oz').quantity).to eq 128
     end
-    
+
     it 'converts to tablespoons' do
       expect(subject.convert_to(:tbsp).quantity).to eq 256
     end
-    
+
     it 'converts to teaspoons' do
       expect(subject.convert_to(:tsp).quantity).to eq 768
     end
   end
-  
+
   describe 'cups' do
     subject { described_class.parse('16 c') }
-    
+
     it 'converts to gallons' do
       expect(subject.convert_to(:gal).quantity).to eq 1
     end
-    
+
     it 'converts to quarts' do
       expect(subject.convert_to(:qt).quantity).to eq 4
     end
-    
+
     it 'converts to pints' do
       expect(subject.convert_to(:pt).quantity).to eq 8
     end
-    
+
     it 'converts to fluid ounces' do
       expect(subject.convert_to(:'fl oz').quantity).to eq 128
     end
-    
+
     it 'converts to tablespoons' do
       expect(subject.convert_to(:tbsp).quantity).to eq 256
     end
-    
+
     it 'converts to teaspoons' do
       expect(subject.convert_to(:tsp).quantity).to eq 768
     end
   end
-  
+
   describe 'fluid ounces' do
     subject { described_class.parse('128 fl oz') }
-    
+
     it 'converts to gallons' do
       expect(subject.convert_to(:gal).quantity).to eq 1
     end
-    
+
     it 'converts to quarts' do
       expect(subject.convert_to(:qt).quantity).to eq 4
     end
-    
+
     it 'converts to pints' do
       expect(subject.convert_to(:pt).quantity).to eq 8
     end
-    
+
     it 'converts to cups' do
       expect(subject.convert_to(:c).quantity).to eq 16
     end
-    
+
     it 'converts to tablespoons' do
       expect(subject.convert_to(:tbsp).quantity).to eq 256
     end
-    
+
     it 'converts to teaspoons' do
       expect(subject.convert_to(:tsp).quantity).to eq 768
     end
   end
-  
+
   describe 'tablespoons' do
     subject { described_class.parse('256 tbsp') }
-    
+
     it 'converts to gallons' do
       expect(subject.convert_to(:gal).quantity).to eq 1
     end
-    
+
     it 'converts to quarts' do
       expect(subject.convert_to(:qt).quantity).to eq 4
     end
-    
+
     it 'converts to pints' do
       expect(subject.convert_to(:pt).quantity).to eq 8
     end
-    
+
     it 'converts to cups' do
       expect(subject.convert_to(:c).quantity).to eq 16
     end
-    
+
     it 'converts to fluid ounces' do
       expect(subject.convert_to(:'fl oz').quantity).to eq 128
     end
-    
+
     it 'converts to teaspoons' do
       expect(subject.convert_to(:tsp).quantity).to eq 768
     end
   end
-  
+
   describe 'teaspoons' do
     subject { described_class.parse('768 tsp') }
-    
+
     it 'converts to gallons' do
       expect(subject.convert_to(:gal).quantity).to eq 1
     end
-    
+
     it 'converts to quarts' do
       expect(subject.convert_to(:qt).quantity).to eq 4
     end
-    
+
     it 'converts to pints' do
       expect(subject.convert_to(:pt).quantity).to eq 8
     end
-    
+
     it 'converts to cups' do
       expect(subject.convert_to(:c).quantity).to eq 16
     end
-    
+
     it 'converts to fluid ounces' do
       expect(subject.convert_to(:'fl oz').quantity).to eq 128
     end
-    
+
     it 'converts to tablespoons' do
       expect(subject.convert_to(:tbsp).quantity).to eq 256
     end

--- a/spec/ruby-measurement/definitions/us_customary/weight_spec.rb
+++ b/spec/ruby-measurement/definitions/us_customary/weight_spec.rb
@@ -5,143 +5,143 @@ require 'spec_helper'
 RSpec.describe Measurement do
   describe 'tons' do
     subject { described_class.parse('1 ton') }
-    
+
     it 'converts to hundredweights' do
       expect(subject.convert_to(:cwt).quantity).to eq 20
     end
-    
+
     it 'converts to pounds' do
       expect(subject.convert_to(:lbs).quantity).to eq 2_000
     end
-    
+
     it 'converts to ounces' do
       expect(subject.convert_to(:oz).quantity).to eq 32_000
     end
-    
+
     it 'converts to drams' do
       expect(subject.convert_to(:dr).quantity).to eq 512_000
     end
-    
+
     it 'converts to grains' do
       expect(subject.convert_to(:gr).quantity).to eq 14_000_000
     end
   end
-  
+
   describe 'hundredweights' do
     subject { described_class.parse('20 cwt') }
-    
+
     it 'converts to tons' do
       expect(subject.convert_to(:ton).quantity).to eq 1
     end
-    
+
     it 'converts to pounds' do
       expect(subject.convert_to(:lbs).quantity).to eq 2_000
     end
-    
+
     it 'converts to ounces' do
       expect(subject.convert_to(:oz).quantity).to eq 32_000
     end
-    
+
     it 'converts to drams' do
       expect(subject.convert_to(:dr).quantity).to eq 512_000
     end
-    
+
     it 'converts to grains' do
       expect(subject.convert_to(:gr).quantity).to eq 14_000_000
     end
   end
-  
+
   describe 'pounds' do
     subject { described_class.parse('2000 lbs') }
-    
+
     it 'converts to tons' do
       expect(subject.convert_to(:ton).quantity).to eq 1
     end
-    
+
     it 'converts to hundredweights' do
       expect(subject.convert_to(:cwt).quantity).to eq 20
     end
-    
+
     it 'converts to ounces' do
       expect(subject.convert_to(:oz).quantity).to eq 32_000
     end
-    
+
     it 'converts to drams' do
       expect(subject.convert_to(:dr).quantity).to eq 512_000
     end
-    
+
     it 'converts to grains' do
       expect(subject.convert_to(:gr).quantity).to eq 14_000_000
     end
   end
-  
+
   describe 'ounces' do
     subject { described_class.parse('32000 oz') }
-    
+
     it 'converts to tons' do
       expect(subject.convert_to(:ton).quantity).to eq 1
     end
-    
+
     it 'converts to hundredweights' do
       expect(subject.convert_to(:cwt).quantity).to eq 20
     end
-    
+
     it 'converts to pounds' do
       expect(subject.convert_to(:lbs).quantity).to eq 2_000
     end
-    
+
     it 'converts to drams' do
       expect(subject.convert_to(:dr).quantity).to eq 512_000
     end
-    
+
     it 'converts to grains' do
       expect(subject.convert_to(:gr).quantity).to eq 14_000_000
     end
   end
-  
+
   describe 'drams' do
     subject { described_class.parse('512000 dr') }
-    
+
     it 'converts to tons' do
       expect(subject.convert_to(:ton).quantity).to eq 1
     end
-    
+
     it 'converts to hundredweights' do
       expect(subject.convert_to(:cwt).quantity).to eq 20
     end
-    
+
     it 'converts to pounds' do
       expect(subject.convert_to(:lbs).quantity).to eq 2_000
     end
-    
+
     it 'converts to ounces' do
       expect(subject.convert_to(:oz).quantity).to eq 32_000
     end
-    
+
     it 'converts to grains' do
       expect(subject.convert_to(:gr).quantity).to eq 14_000_000
     end
   end
-  
+
   describe 'grains' do
     subject { described_class.parse('14000000 gr') }
-    
+
     it 'converts to tons' do
       expect(subject.convert_to(:ton).quantity).to eq 1
     end
-    
+
     it 'converts to hundredweights' do
       expect(subject.convert_to(:cwt).quantity).to eq 20
     end
-    
+
     it 'converts to pounds' do
       expect(subject.convert_to(:lbs).quantity).to eq 2_000
     end
-    
+
     it 'converts to ounces' do
       expect(subject.convert_to(:oz).quantity).to eq 32_000
     end
-    
+
     it 'converts to drams' do
       expect(subject.convert_to(:dr).quantity).to eq 512_000
     end

--- a/spec/ruby-measurement/measurement_spec.rb
+++ b/spec/ruby-measurement/measurement_spec.rb
@@ -1,338 +1,372 @@
+# encoding: UTF-8
+
 require 'spec_helper'
 
 RSpec.describe Measurement do
   subject { described_class }
-  
+
   describe '.new' do
     describe 'with valid quantity' do
       it 'sets the quantity' do
         expect(subject.new(3).quantity).to eq 3
       end
-      
+
       it 'sets the default unit' do
         expect(subject.new(3).unit).to eq subject::Unit[:count]
       end
     end
-    
+
     describe 'with valid quantity and unit name' do
       it 'sets the quantity' do
         expect(subject.new(2, :dozen).quantity).to eq 2
       end
-      
+
       it 'sets the unit' do
         expect(subject.new(2, :dozen).unit).to eq subject::Unit[:dozen]
       end
     end
-    
+
     describe 'with valid quantity and unit' do
       it 'sets the quantity' do
         expect(subject.new(2, subject::Unit[:dozen]).quantity).to eq 2
       end
-      
+
       it 'sets the unit' do
         expect(subject.new(2, subject::Unit[:dozen]).unit).to eq subject::Unit[:dozen]
       end
     end
-    
+
     describe 'with invalid quantity' do
       it 'raises exception' do
         expect { subject.new('hi') }.to raise_exception
       end
     end
-    
+
     describe 'with invalid unit' do
       it 'raises exception' do
         expect { subject.new(3, :finklebaum) }.to raise_exception
       end
     end
   end
-  
+
   describe '.parse' do
     describe 'quantity' do
       it 'parses scientific notation' do
         m = subject.parse('4.3e12')
         expect(m.quantity).to eq 4.3e12
         expect(m.unit).to eq Measurement::Unit[:count]
-        
+
         m = subject.parse('4.3e12 dozen')
         expect(m.quantity).to eq 4.3e12
         expect(m.unit).to eq Measurement::Unit[:dozen]
-        
+
         m = subject.parse('4.3e12doz')
         expect(m.quantity).to eq 4.3e12
         expect(m.unit).to eq Measurement::Unit[:dozen]
       end
-      
+
       it 'parses fractions' do
         m = subject.parse('1/4')
         expect(m.quantity).to eq 0.25
         expect(m.unit).to eq Measurement::Unit[:count]
-        
+
         m = subject.parse('1/4 dozen')
         expect(m.quantity).to eq 0.25
         expect(m.unit).to eq Measurement::Unit[:dozen]
-        
+
         m = subject.parse('1/4doz')
         expect(m.quantity).to eq 0.25
         expect(m.unit).to eq Measurement::Unit[:dozen]
       end
-      
+
       it 'parses mixed fractions' do
         m = subject.parse('3 2/5')
         expect(m.quantity).to eq 3.4
         expect(m.unit).to eq Measurement::Unit[:count]
-        
+
         m = subject.parse('3 2/5 dozen')
         expect(m.quantity).to eq 3.4
         expect(m.unit).to eq Measurement::Unit[:dozen]
-        
-        m = subject.parse('3 2/5')
-        expect(m.quantity).to eq 3.4
-        expect(m.unit).to eq Measurement::Unit[:count]
       end
-      
+
+      it 'parses fractions with special characters' do
+        m = subject.parse('⅜')
+        expect(m.quantity).to eq 0.375
+        expect(m.unit).to eq Measurement::Unit[:count]
+
+        m = subject.parse('⅜ dozen')
+        expect(m.quantity).to eq 0.375
+        expect(m.unit).to eq Measurement::Unit[:dozen]
+
+        m = subject.parse('⅜doz')
+        expect(m.quantity).to eq 0.375
+        expect(m.unit).to eq Measurement::Unit[:dozen]
+      end
+
+      it 'parses mixed fractions with special characters' do
+        m = subject.parse('3⅜')
+        expect(m.quantity).to eq 3.375
+        expect(m.unit).to eq Measurement::Unit[:count]
+
+        m = subject.parse('3 ⅜')
+        expect(m.quantity).to eq 3.375
+        expect(m.unit).to eq Measurement::Unit[:count]
+
+        m = subject.parse('3⅜ dozen')
+        expect(m.quantity).to eq 3.375
+        expect(m.unit).to eq Measurement::Unit[:dozen]
+
+        m = subject.parse('3 ⅜ dozen')
+        expect(m.quantity).to eq 3.375
+        expect(m.unit).to eq Measurement::Unit[:dozen]
+
+        m = subject.parse('3⅜doz')
+        expect(m.quantity).to eq 3.375
+        expect(m.unit).to eq Measurement::Unit[:dozen]
+      end
+
       it 'parses decimals' do
         m = subject.parse('2.1')
         expect(m.quantity).to eq 2.1
         expect(m.unit).to eq Measurement::Unit[:count]
-        
+
         m = subject.parse('2.1 dozen')
         expect(m.quantity).to eq 2.1
         expect(m.unit).to eq Measurement::Unit[:dozen]
-        
+
         m = subject.parse('2.1doz')
         expect(m.quantity).to eq 2.1
         expect(m.unit).to eq Measurement::Unit[:dozen]
       end
     end
-    
+
     describe 'unit' do
       it 'converts when defined' do
         expect(subject.parse('3 dozen').unit).to eq Measurement::Unit[:dozen]
       end
-      
+
       it 'raises exception when undefined' do
         expect { subject.parse('3 finklebaums') }.to raise_error
       end
     end
   end
-  
+
   describe '.define' do
     it 'delegates to Unit.define' do
       expect(Measurement::Unit).to receive(:define)
       subject.define(:something)
     end
   end
-  
+
   describe '#convert_to' do
     let(:measurement) { subject.new(3) }
-    
+
     it 'returns copy of self when target unit matches current unit' do
       result = measurement.convert_to(:count)
       expect(result).to_not be measurement
       expect(result).to eq measurement
     end
-    
+
     it 'returns target unit if it exists and is convertable' do
       result = measurement.convert_to(:dozen)
       expect(result.quantity).to eq 0.25
       expect(result.unit).to eq Measurement::Unit[:dozen]
     end
-    
+
     it 'raises exception if unit exists and is not convertable' do
       expect { measurement.convert_to(:inches) }.to raise_error
     end
-    
+
     it 'raises exception if unit does not exist' do
       expect { measurement.convert_to(:finklebaum) }.to raise_error
     end
   end
-  
+
   describe '#convert_to!' do
     let(:measurement) { subject.new(3) }
-    
+
     it 'modifies the object' do
       measurement.convert_to!(:dozen)
       expect(measurement.quantity).to eq 0.25
       expect(measurement.unit).to eq Measurement::Unit[:dozen]
     end
   end
-  
+
   describe '#+' do
     let(:measurement) { subject.new(3) }
-    
+
     it 'adds numeric values' do
       result = measurement + 4
       expect(result.quantity).to eq 7
       expect(result.unit).to eq measurement.unit
     end
-    
+
     it 'adds units of the same type' do
       other = subject.new(4)
       expect(other.unit).to eq measurement.unit
-      
+
       result = measurement + other
       expect(result.quantity).to eq 7
       expect(result.unit).to eq measurement.unit
     end
-    
+
     it 'adds units of a convertable type' do
       other = subject.new(2, :dozen)
       expect(other.unit).to_not eq measurement.unit
-      
+
       result = measurement + other
       expect(result.quantity).to eq 27
       expect(result.unit).to eq measurement.unit
     end
-    
+
     it 'raises exception for incompatible units' do
       other = subject.new(4, :inches)
       expect(other.unit).to_not eq measurement.unit
       expect { measurement + other }.to raise_error
     end
   end
-  
+
   describe '#-' do
     let(:measurement) { subject.new(3) }
-    
+
     it 'subtracts numeric values' do
       result = measurement - 4
       expect(result.quantity).to eq -1
       expect(result.unit).to eq measurement.unit
     end
-    
+
     it 'subtracts units of the same type' do
       other = subject.new(4)
       expect(other.unit).to eq measurement.unit
-      
+
       result = measurement - other
       expect(result.quantity).to eq -1
       expect(result.unit).to eq measurement.unit
     end
-    
+
     it 'subtracts units of a convertable type' do
       other = subject.new(2, :dozen)
       expect(other.unit).to_not eq measurement.unit
-      
+
       result = measurement - other
       expect(result.quantity).to eq -21
       expect(result.unit).to eq measurement.unit
     end
-    
+
     it 'raises exception for incompatible units' do
       other = subject.new(4, :inches)
       expect(other.unit).to_not eq measurement.unit
       expect { measurement - other }.to raise_error
     end
   end
-  
+
   describe '#*' do
     let(:measurement) { subject.new(3) }
-    
+
     it 'multiplies numeric values' do
       result = measurement * 4
       expect(result.quantity).to eq 12
       expect(result.unit).to eq measurement.unit
     end
-    
+
     it 'multiplies units of the same type' do
       other = subject.new(4)
       expect(other.unit).to eq measurement.unit
-      
+
       result = measurement * other
       expect(result.quantity).to eq 12
       expect(result.unit).to eq measurement.unit
     end
-    
+
     it 'multiplies units of a convertable type' do
       other = subject.new(2, :dozen)
       expect(other.unit).to_not eq measurement.unit
-      
+
       result = measurement * other
       expect(result.quantity).to eq 72
       expect(result.unit).to eq measurement.unit
     end
-    
+
     it 'raises exception for incompatible units' do
       other = subject.new(4, :inches)
       expect(other.unit).to_not eq measurement.unit
       expect { measurement * other }.to raise_error
     end
   end
-  
+
   describe '#/' do
     let(:measurement) { subject.new(12) }
-    
+
     it 'divides numeric values' do
       result = measurement / 4
       expect(result.quantity).to eq 3
       expect(result.unit).to eq measurement.unit
     end
-    
+
     it 'divides units of the same type' do
       other = subject.new(4)
       expect(other.unit).to eq measurement.unit
-      
+
       result = measurement / other
       expect(result.quantity).to eq 3
       expect(result.unit).to eq measurement.unit
     end
-    
+
     it 'divides units of a convertable type' do
       other = subject.new(1, :dozen)
       expect(other.unit).to_not eq measurement.unit
-      
+
       result = measurement / other
       expect(result.quantity).to eq 1
       expect(result.unit).to eq measurement.unit
     end
-    
+
     it 'raises exception for incompatible units' do
       other = subject.new(4, :inches)
       expect(other.unit).to_not eq measurement.unit
       expect { measurement / other }.to raise_error
     end
   end
-  
+
   describe '#**' do
     let(:measurement) { subject.new(3) }
-    
+
     it 'raises to the power of numeric values' do
       expect((measurement ** 3).quantity).to eq 27
     end
-    
+
     it 'raises exception for non-numeric values' do
       expect { measurement ** subject.new(3) }.to raise_error
     end
   end
-  
+
   describe '#==' do
     let(:measurement) { subject.new(3) }
-    
+
     it 'returns true for measurements with same quantity and unit' do
       expect(measurement == subject.new(3)).to be true
     end
-    
+
     it 'returns false for measurements with same quantity and different unit' do
       expect(measurement == subject.new(3, :dozen)).to be false
     end
-    
+
     it 'returns false for measurements with same unit and different quantity' do
       expect(measurement == subject.new(4)).to be false
     end
-    
+
     it 'returns false for non-measurement objects' do
       expect(measurement == 3).to be false
     end
   end
-  
+
   describe '#to_s' do
     it 'returns the quantity and unit' do
       expect(subject.new(3.5).to_s).to eq '3.5 count'
       expect(subject.new(2, :dozen).to_s).to eq '2 doz'
     end
   end
-  
+
   describe '#inspect' do
     it 'returns the quantity and unit' do
       expect(subject.new(3.5).inspect).to eq '3.5 count'

--- a/spec/ruby-measurement/unit_builder_spec.rb
+++ b/spec/ruby-measurement/unit_builder_spec.rb
@@ -2,33 +2,33 @@ require 'spec_helper'
 
 RSpec.describe Measurement::Unit::Builder do
   subject { described_class.new(name, &block) }
-  
+
   let(:name) { :hour }
   let(:block) { proc {} }
-  
+
   describe '.new' do
     describe 'with a block' do
       let(:block) do
         proc { |unit| unit.alias :hr, :hrs }
       end
-      
+
       it 'should evaluate the block' do
         unit = subject.to_unit
         expect(unit.aliases).to include 'hr'
         expect(unit.aliases).to include 'hrs'
       end
     end
-    
+
     describe 'without a block' do
       let(:block) { nil }
-      
+
       it 'should not evaluate the block' do
         unit = subject.to_unit
         expect(unit.aliases).to_not include 'hr'
       end
     end
   end
-  
+
   describe '#to_unit' do
     it 'should return a matching unit' do
       expect(subject.to_unit).to be_a Measurement::Unit
@@ -36,13 +36,13 @@ RSpec.describe Measurement::Unit::Builder do
       expect(subject.to_unit.aliases).to eq %w(hour).to_set
     end
   end
-  
+
   describe '#alias' do
     describe 'with a new alias' do
       before do
         expect(subject.to_unit.aliases).to_not include 'hr'
       end
-      
+
       it 'should append the new alias' do
         aliases = subject.to_unit.aliases.dup
         subject.alias :hr
@@ -50,19 +50,19 @@ RSpec.describe Measurement::Unit::Builder do
         expect(subject.to_unit.aliases).to include 'hr'
       end
     end
-    
+
     describe 'with multiple new aliases' do
       before do
         expect(subject.to_unit.aliases).to_not include 'hr'
         expect(subject.to_unit.aliases).to_not include 'hrs'
       end
     end
-    
+
     describe 'with an existing alias' do
       before do
         subject.alias :hour
       end
-      
+
       it 'should not affect the list of aliases' do
         aliases = subject.to_unit.aliases.dup
         subject.alias :hour
@@ -70,13 +70,13 @@ RSpec.describe Measurement::Unit::Builder do
       end
     end
   end
-  
+
   describe '#convert_to' do
     describe 'with a new target alias' do
       before do
         expect(subject.to_unit.conversions['min']).to be_nil
       end
-      
+
       it 'should add the conversion' do
         conversion = proc { |value| value * 60.0 }
         expect(subject.to_unit.aliases).to_not include 'hr'
@@ -84,13 +84,13 @@ RSpec.describe Measurement::Unit::Builder do
         expect(subject.to_unit.conversions['min']).to eq conversion
       end
     end
-    
+
     describe 'with an existing target alias' do
       before do
         subject.convert_to(:min) { |value| value + 3 }
         expect(subject.to_unit.conversions['min']).to_not be_nil
       end
-      
+
       it 'should replace the conversion' do
         conversion = proc { |value| value * 60.0 }
         expect(subject.to_unit.aliases).to_not include 'hr'

--- a/spec/ruby-measurement/unit_spec.rb
+++ b/spec/ruby-measurement/unit_spec.rb
@@ -2,85 +2,85 @@ require 'spec_helper'
 
 RSpec.describe Measurement::Unit do
   subject { described_class.new(name) }
-  
+
   let(:name) { :hour }
-  
+
   describe '#name' do
     it 'returns the name' do
       expect(subject.name).to eq 'hour'
     end
   end
-  
+
   describe '#add_alias' do
     it 'adds new aliases' do
       subject.add_alias :hr, :hrs
       expect(subject.aliases).to eq %w(hour hr hrs).to_set
     end
-    
+
     it 'does not add aliases that already exist' do
       subject.add_alias :hr, :hrs
       expect { subject.add_alias :hr, :hrs }.to_not raise_error
       expect(subject.aliases).to eq %w(hour hr hrs).to_set
     end
   end
-  
+
   describe '#add_conversion' do
     before do
       subject.add_conversion(:sec) { |value| value * 3600.0 }
     end
-    
+
     it 'adds new conversions' do
       conversion = proc { |value| value * 60.0 }
       subject.add_conversion(:min, &conversion)
       expect(subject.conversions['min']).to be conversion
     end
-    
+
     it 'replaces existing conversions' do
       conversion = proc { |value| value * 60.0 }
       subject.add_conversion(:sec, &conversion)
       expect(subject.conversions['sec']).to be conversion
     end
   end
-  
+
   describe '#aliases' do
     it 'returns the set of aliases' do
       expect(subject.aliases).to eq %w(hour).to_set
     end
   end
-  
+
   describe '#conversion' do
     before do
       described_class.define(:min)
       subject.add_conversion(:min) { |value| value * 60.0 }
     end
-    
+
     it 'returns conversion if it exists' do
       expect(subject.conversion(:min)).to_not be_nil
     end
-    
+
     it 'returns nil if it does not exist' do
       expect(subject.conversion(:sec)).to be_nil
     end
   end
-  
+
   describe '#inspect' do
     it 'returns name' do
       expect(subject.inspect).to eq subject.name
     end
   end
-  
+
   describe '#to_s' do
     it 'returns name' do
       expect(subject.inspect).to eq subject.name
     end
   end
-  
+
   describe '#==' do
     before do
       subject.add_alias(:hours, :hr, :hrs)
       subject.add_conversion(:min) { |value| value * 60.0 }
     end
-    
+
     describe 'other object is a Unit' do
       it 'returns true when name, aliases, and conversions match' do
         other = described_class.new(:hour)
@@ -88,21 +88,21 @@ RSpec.describe Measurement::Unit do
         other.add_conversion(:min) { |value| value * 60.0 }
         expect(subject == other).to be true
       end
-      
+
       it "returns false when the name doesn't match" do
         other = described_class.new(:hoooour)
         other.add_alias(:hours, :hr, :hrs)
         other.add_conversion(:min) { |value| value * 60.0 }
         expect(subject == other).to be false
       end
-      
+
       it "returns false when the aliases don't match" do
         other = described_class.new(:hour)
         other.add_alias(:hoooours, :hr, :hrs)
         other.add_conversion(:min) { |value| value * 60.0 }
         expect(subject == other).to be false
       end
-      
+
       it "returns false when the conversions don't match" do
         other = described_class.new(:hour)
         other.add_alias(:hours, :hr, :hrs)
@@ -110,41 +110,41 @@ RSpec.describe Measurement::Unit do
         expect(subject == other).to be false
       end
     end
-    
+
     describe 'other object is not a Unit' do
       it 'returns false' do
         expect(subject == :hour).to be false
       end
     end
   end
-  
+
   describe '.names' do
     subject { described_class }
-    
+
     it 'returns all defined unit names' do
       unit_names = subject.names
       expect(unit_names).to be_an Array
       expect(unit_names).to include 'count'
     end
   end
-  
+
   describe '.define' do
     subject { described_class }
-    
+
     it 'returns a unit builder' do
       builder = subject.define(:count)
       expect(builder).to be_a Measurement::Unit::Builder
     end
-    
+
     it 'accepts a block' do
       builder = subject.define(:count) { |b| b.alias :ct }
       expect(builder).to be_a Measurement::Unit::Builder
     end
   end
-  
+
   describe '.[]' do
     subject { described_class }
-    
+
     describe 'for a unit name that is defined' do
       it 'returns the unit' do
         unit = subject[:dozen]
@@ -153,7 +153,7 @@ RSpec.describe Measurement::Unit do
         expect(unit.aliases).to eq %w(doz dozen).to_set
       end
     end
-    
+
     describe 'for a unit name that is not defined' do
       it 'returns nil' do
         expect(subject[:potato]).to be nil


### PR DESCRIPTION
This change addresses what was called out in #6.  It allows fraction characters (½, ⅓, etc.) to be parsed by the Measurement class.  /cc @Korkey128k