### PR TITLE
Fix documentation for listing all unit keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ that will be used when displaying a measurement.
 
 List all keys you can use as unit
 
-    Measurement.names                           # => ['count','doz','dozen',...]
+    Measurement::Unit.names                    # => ['count','doz','dozen',...]
 
 ## Contributing
 


### PR DESCRIPTION
The documentation method for listing the keys doesn't work.
v 1.2.3
```bash
> Measurement.names
NoMethodError: undefined method `names' for Measurement:Class
```

Tested if the other method worked for defining a new unit (it does)
```bash
Measurement.define(:day) do |unit|
  unit.alias :days
  unit.convert_to(:week) { |value| value / 7.0 }
  unit.convert_to(:year) { |value| value / 365.0 }
end
=> #<Measurement::Unit::Builder:0x007ffd36de9938 @unit=day>
> 
```
Tried `Measurement::Unit.names` and 💥 , it worked! This pr is to update the documentation. 

