### PR TITLE
Add conversion for US customary lenght units to centimeter unit

### DIFF
--- a/lib/ruby-measurement/definitions/us_customary/length.rb
+++ b/lib/ruby-measurement/definitions/us_customary/length.rb
@@ -9,6 +9,7 @@ Measurement.define(:'mi.') do |unit|
   unit.convert_to(:ft) { |value| value * 5_280.0 }
   unit.convert_to(:in) { |value| value * 63_360.0 }
   unit.convert_to(:th) { |value| value * 63_360_000.0 }
+  unit.convert_to(:cm) { |value| value * 160_934.4 }
 end
 
 Measurement.define(:'fur.') do |unit|
@@ -20,6 +21,7 @@ Measurement.define(:'fur.') do |unit|
   unit.convert_to(:ft) { |value| value * 660.0 }
   unit.convert_to(:in) { |value| value * 7_920.0 }
   unit.convert_to(:th) { |value| value * 7_920_000.0 }
+  unit.convert_to(:cm) { |value| value * 20_116.84 }
 end
 
 Measurement.define(:'ch.') do |unit|
@@ -31,6 +33,7 @@ Measurement.define(:'ch.') do |unit|
   unit.convert_to(:ft) { |value| value * 66.0 }
   unit.convert_to(:in) { |value| value * 792.0 }
   unit.convert_to(:th) { |value| value * 792_000.0 }
+  unit.convert_to(:cm) { |value| value * 2_011.68 }
 end
 
 Measurement.define(:'ftm.') do |unit|
@@ -42,6 +45,7 @@ Measurement.define(:'ftm.') do |unit|
   unit.convert_to(:ft) { |value| value * 6.0 }
   unit.convert_to(:in) { |value| value * 72.0 }
   unit.convert_to(:th) { |value| value * 72_000.0 }
+  unit.convert_to(:cm) { |value| value * 182.88 }
 end
 
 Measurement.define(:'yd.') do |unit|
@@ -53,6 +57,7 @@ Measurement.define(:'yd.') do |unit|
   unit.convert_to(:ft) { |value| value * 3.0 }
   unit.convert_to(:in) { |value| value * 36.0 }
   unit.convert_to(:th) { |value| value * 36_000.0 }
+  unit.convert_to(:cm) { |value| value * 91.44 }
 end
 
 Measurement.define(:'ft.') do |unit|
@@ -64,6 +69,7 @@ Measurement.define(:'ft.') do |unit|
   unit.convert_to(:ftm) { |value| value / 6.0 }
   unit.convert_to(:in) { |value| value * 12.0 }
   unit.convert_to(:th) { |value| value * 12_000.0 }
+  unit.convert_to(:cm) { |value| value * 30.48 }
 end
 
 Measurement.define(:'in.') do |unit|
@@ -75,6 +81,7 @@ Measurement.define(:'in.') do |unit|
   unit.convert_to(:yd) { |value| value / 36.0 }
   unit.convert_to(:ft) { |value| value / 12.0 }
   unit.convert_to(:th) { |value| value * 1000.0 }
+  unit.convert_to(:cm) { |value| value * 2.54 }
 end
 
 Measurement.define(:'th.') do |unit|
@@ -86,4 +93,5 @@ Measurement.define(:'th.') do |unit|
   unit.convert_to(:yd) { |value| value / 36_000.0 }
   unit.convert_to(:ft) { |value| value / 12_000.0 }
   unit.convert_to(:in) { |value| value / 1000.0 }
+  unit.convert_to(:cm) { |value| value * 0.00_254 }
 end

--- a/spec/ruby-measurement/definitions/us_customary/length_spec.rb
+++ b/spec/ruby-measurement/definitions/us_customary/length_spec.rb
@@ -33,6 +33,10 @@ RSpec.describe Measurement do
     it 'converts to thou' do
       expect(subject.convert_to(:th).quantity).to eq 63_360_000
     end
+
+    it 'converts to centimeters' do
+      expect(subject.convert_to(:cm).quantity).to eq 160_934.4
+    end
   end
 
   describe 'furlongs' do
@@ -64,6 +68,10 @@ RSpec.describe Measurement do
 
     it 'converts to thou' do
       expect(subject.convert_to(:th).quantity).to eq 63_360_000
+    end
+
+    it 'converts to centimeters' do
+      expect(subject.convert_to(:cm).quantity).to eq 160_934.72
     end
   end
 
@@ -97,6 +105,10 @@ RSpec.describe Measurement do
     it 'converts to thou' do
       expect(subject.convert_to(:th).quantity).to eq 63_360_000
     end
+
+    it 'converts to centimeters' do
+      expect(subject.convert_to(:cm).quantity).to eq 160_934.4
+    end
   end
 
   describe 'fathoms' do
@@ -128,6 +140,10 @@ RSpec.describe Measurement do
 
     it 'converts to thou' do
       expect(subject.convert_to(:th).quantity).to eq 63_360_000
+    end
+
+    it 'converts to centimeters' do
+      expect(subject.convert_to(:cm).quantity).to eq 160_934.4
     end
   end
 
@@ -161,6 +177,10 @@ RSpec.describe Measurement do
     it 'converts to thou' do
       expect(subject.convert_to(:th).quantity).to eq 63_360_000
     end
+
+    it 'converts to centimeters' do
+      expect(subject.convert_to(:cm).quantity).to eq 160_934.4
+    end
   end
 
   describe 'feet' do
@@ -192,6 +212,10 @@ RSpec.describe Measurement do
 
     it 'converts to thou' do
       expect(subject.convert_to(:th).quantity).to eq 63_360_000
+    end
+
+    it 'converts to centimeters' do
+      expect(subject.convert_to(:cm).quantity).to eq 160_934.4
     end
   end
 
@@ -225,6 +249,10 @@ RSpec.describe Measurement do
     it 'converts to thou' do
       expect(subject.convert_to(:th).quantity).to eq 63_360_000
     end
+
+    it 'converts to centimeters' do
+      expect(subject.convert_to(:cm).quantity).to eq 160_934.4
+    end
   end
 
   describe 'thou' do
@@ -256,6 +284,10 @@ RSpec.describe Measurement do
 
     it 'converts to inches' do
       expect(subject.convert_to(:in).quantity).to eq 63_360
+    end
+
+    it 'converts to centimeters' do
+      expect(subject.convert_to(:cm).quantity).to eq 160_934.40000000002
     end
   end
 end


### PR DESCRIPTION
Almost all conversion numbers was based on [metric-conversions.org](http://www.metric-conversions.org/length).

The `fathom` conversion was based on [asknumbers.com](https://www.asknumbers.com/CentimetersToFathomConversion.aspx).

The `thou` conversion was based on [convertunits.com](https://www.convertunits.com/from/thou/to/centimeters).