### PR TITLE
Use Github Actions for CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,0 +1,30 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby:
+          - head
+          - '3.0'
+          - '2.7'
+          - '2.6'
+          - '2.5'
+    continue-on-error: ${{ matrix.ruby == 'head' }}
+    name: Ruby ${{ matrix.ruby }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+      - run: |
+          bundle exec rake

--- a/tasks/rspec.rake
+++ b/tasks/rspec.rake
@@ -2,5 +2,5 @@ require 'rspec/core/rake_task'
 
 desc 'Run all examples'
 RSpec::Core::RakeTask.new(:spec) do |t|
-  t.rspec_opts = %w(--color)
+  t.rspec_opts = %w(--force-color)
 end


### PR DESCRIPTION
* Updates tested Ruby versions to currently supported ones
* Use RSpec flag --force-color over --color

I know this project hasn't seen much activity recently, but I'd like to keep this up to date just so anyone relying on it can know it won't be a blocker for Ruby version updates.

Sample run: https://github.com/mlarraz/ruby-measurement/actions/runs/1076572836

This won't actually run in the context of the original repo until the PR is merged.